### PR TITLE
Minor change in UserProtectWrapper

### DIFF
--- a/frontend/src/pages/UserProtectWrapper.jsx
+++ b/frontend/src/pages/UserProtectWrapper.jsx
@@ -22,7 +22,7 @@ const UserProtectWrapper = ({
             }
         }).then(response => {
             if (response.status === 200) {
-                setUser(response.data)
+                setUser(response.data.user)
                 setIsLoading(false)
             }
         })


### PR DESCRIPTION
Previously the whole data of the response was getting saved into user but now it only saves the user object using setUser